### PR TITLE
Portability for OpenBSD

### DIFF
--- a/src/ne.c
+++ b/src/ne.c
@@ -332,7 +332,7 @@ int main(int argc, char **argv) {
 		const int error = load_fh_in_buffer(cur_buffer, fileno(stdin));
 		print_error(error);
 
-		if (!(stdin = freopen("/dev/tty", "r", stdin))) {
+		if (!(freopen("/dev/tty", "r", stdin))) {
 			fprintf(stderr, "Cannot reopen input tty\n");
 			abort();
 		}

--- a/src/regex_internal.h
+++ b/src/regex_internal.h
@@ -418,7 +418,9 @@ static unsigned int re_string_context_at (const re_string_t *input, int idx,
 #define re_string_skip_bytes(pstr,idx) ((pstr)->cur_idx += (idx))
 #define re_string_set_index(pstr,idx) ((pstr)->cur_idx = (idx))
 
+#if !defined(__OpenBSD__)
 #include <alloca.h>
+#endif
 
 #ifndef _LIBC
 # if HAVE_ALLOCA


### PR DESCRIPTION
Hi -- I maintain the OpenBSD port of ne (see http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/editors/ne/ ).
Here are some portability fixes for OpenBSD (and likely the other BSDs as well):
1. There is no alloca.h header, alloca() is part of stdlib.h (it will be up to other projects to add themselves to the #if !defined... block)
2. stdin can't be used as an lvalue (and probably doesn't really need to be here anyway)