### PR TITLE
make building the pdf optional

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,6 +44,10 @@ target requires a complete build, and in particular the presence of a
 number of tools that manipulate texinfo files, as some of the source files
 are generated from the documentation.
 
+By default the build target does not produce the documentation PDF since
+that depends on pdftex. If you still want to build the PDF you can do that
+using `make alldocs build install`.
+
 By playing with the low-level src makefile you have more options (as you can
 first build using the low-level makefile and then use the install target
 of the top-level makefile). If you have a termcap database, you should

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,1 +1,16 @@
 version.texinfo
+html/
+*.gz
+ne.txt
+ne.txt-e
+ne.aux
+ne.cm
+ne.cp
+ne.fn
+ne.ky
+ne.log
+ne.pg
+ne.toc
+ne.tp
+ne.vr
+*.pdf

--- a/doc/makefile
+++ b/doc/makefile
@@ -5,14 +5,13 @@
 # document (ne.pdf).
 #
 
-INFODOCS=ne.info.gz
-INFODOCSNUM=ne.info-1.gz ne.info-2.gz ne.info-3.gz ne.info-4.gz
+DOCS=ne.info.gz ne.txt html/index.html
 
-DOCS=$(INFODOCS) ne.txt html/index.html ne.dvi ne.pdf
+docs: $(DOCS)
 
-all: $(DOCS)
+pdf: ne.pdf
 
-install: all
+install: docs
 	cp * ../../../doc
 
 version.texinfo:
@@ -24,7 +23,7 @@ ne.txt: ne.texinfo version.texinfo
 	sed -i -e "s/''''/'\`''/g" ne.txt
 	sed -i -e "s/'ne'/ne/g" ne.txt
 
-$(INFODOCS): ne.texinfo version.texinfo
+ne.info.gz: ne.texinfo version.texinfo
 	makeinfo ne.texinfo
 	sed -i -e "s/\`/'/g" ne.info
 	sed -i -e "s/''''/'\`''/g" ne.info
@@ -40,5 +39,5 @@ html/index.html: ne.texinfo version.texinfo
 	makeinfo --html -o html ne.texinfo
 
 clean:
-	rm -f ne.txt ne.info* ne.ps ne.pdf ne.dvi
+	rm -f ne.txt ne.info* ne.ps ne.pdf
 	rm -rf html/

--- a/makefile
+++ b/makefile
@@ -25,11 +25,13 @@ build: docs
 docs:
 	( cd doc; make )
 
+alldocs: docs
+	( cd doc; make pdf )
+
 version:
 	./version.pl VERSION=$(VERSION)
 
-source: version
-	( cd doc; make )
+source: version alldocs
 	( cd src; make clean; make )
 	-rm -f ne-$(VERSION)
 	ln -s . ne-$(VERSION)
@@ -58,7 +60,8 @@ install:
 	cp -p syntax/*.jsf $(DESTDIR)$(PREFIX)/share/ne/syntax
 	cp -p macros/*     $(DESTDIR)$(PREFIX)/share/ne/macros
 	cp -p doc/ne.1 $(DESTDIR)$(PREFIX)/share/man/man1
-	cp -pr doc/ne.pdf doc/html doc/ne.txt doc/default.* README.md COPYING NEWS CHANGES $(DESTDIR)$(PREFIX)/share/doc/ne
+	cp -pR doc/html doc/ne.txt doc/default.* README.md COPYING NEWS CHANGES $(DESTDIR)$(PREFIX)/share/doc/ne
+	if [ -f doc/ne.pdf ]; then cp -p doc/ne.pdf $(DESTDIR)$(PREFIX)/share/doc/ne ; fi
 	cp -p doc/ne.info.gz $(DESTDIR)$(PREFIX)/share/info
 	-install-info --dir-file=$(DESTDIR)$(PREFIX)/share/info/dir $(DESTDIR)$(PREFIX)/share/info/ne.info.gz
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,3 +9,4 @@ names.h
 ne
 version.h
 *.gcno
+*.o


### PR DESCRIPTION
### Issue

Right now installing ne with `cd ne-x.y.z && make build install` requires an installed tex distribution to build the documentation pdf. This is suboptimal for minimal distributions (server) or source-based package managers (Homebrew, ports etc.) since it adds a pretty big dependency.

### Solution

This PR moves the pdf build to a non-default target that can be invoked using `make alldocs` or `cd doc && make pdf`. The new syntax to install ne with the pdf would then be `make alldocs build install`.

### Drawbacks

The downside of this change is that it essentially removes the most accessible piece of documentation from a source-install. On the other hand the PDF has much more exposure on the website than in `share/doc/`. It should also be considered that on minimal systems without X, there are no facilities to view the pdf in the first place.

### Alternatives considered

Add a command-line option (via a environment variable) that disables building the pdf. The drawback of this option is that for people building from source who get an error about pdftex would first have to read through Install.md to find out about the option.