### PR TITLE
Add error handling code for chdir

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -739,7 +739,12 @@ char *complete_filename(const char *start_prefix) {
 	}
 
 	if (cur_dir_name != NULL) {
-		chdir(cur_dir_name);
+		if (chdir(cur_dir_name) == -1) {
+			free(cur_dir_name);
+			free(dir_name);
+			free(cur_prefix);
+			return NULL;
+		}
 		free(cur_dir_name);
 	}
 	free(dir_name);
@@ -892,7 +897,10 @@ char *request_files(const char * const filename, bool use_prefix) {
 		req_list_free(&rl);
 	} while(next_dir);
 
-	chdir(cur_dir_name);
+	if (chdir(cur_dir_name) == -1) {
+		free(cur_dir_name);
+		return NULL;
+	}
 	free(cur_dir_name);
 
 	return result;


### PR DESCRIPTION
Hi, 

I analyzed the source code and find chdir missing error handling code, which may cause potential bugs. 

I think it's unsafe to assume the library function would be correct. It would be better if we could handle the error properly.

Best,
Zhouyang