### PR TITLE
Allow --macro argument to be specified for each file

### DIFF
--- a/doc/ne.1
+++ b/doc/ne.1
@@ -78,7 +78,8 @@ Use the specified keyboard configuration file.
 Use the specified menu configuration file.
 .TP
 .I "--macro macro-file"
-Execute the given macro after startup.
+Execute the given macro on the next file or first buffer after startup.
+May appear more than once.
 .SS USAGE
 Start \fBne\fR, then use escape, escape-escape or F1 to access the menus.
 .SS BUGS


### PR DESCRIPTION
I'd like to be able to apply a macro to all files on startup. For example, so I can have a shortcut along the lines of ``grep -rl thing-i-want-to-change . | xargs -o ne --macro find-thing-i-want-to-change.macro``.

Currently, ``--macro`` works on the current buffer [after all files are opened](https://github.com/vigna/ne/blob/master/src/ne.c#L446). So...

```
ne --macro x.macro a.txt b.txt
```

...will apply ``x.macro`` to ``a.txt`` but not ``b.txt``. ``x.macro`` can't switch documents and process ``b.txt``, since it operates on a buffer, not globally.

This pull allows me to specify ``--macro`` for the next file, in the same manner as ``--read-only``, etc. It's nearly backward compatible:

* ``ne --macro x.macro a.txt b.txt``: Same, runs macro on ``a.txt``, which is first buffer.
* ``ne a.txt b.txt  --macro x.macro``: Same, runs macro on first buffer.
* ``ne a.txt --macro x.macro b.txt``: Runs macro on ``b.txt``, instead of ``a.txt`` as currently.

The other obvious way around this is if ``--macro`` applies to every buffer loaded. This would be more useful for me, but less backwardly-compatible and less consistent with the other options I thought.
