### PR TITLE
Updated the keywords for python 3.x

### DIFF
--- a/syntax/python.jsf
+++ b/syntax/python.jsf
@@ -80,6 +80,8 @@
 	"and"		kw
 	"as"		kw
 	"assert"	kw
+	"async"		kw
+	"await"		kw
 	"break"		kw
 	"class"		declkw
 	"continue"	kw
@@ -88,7 +90,6 @@
 	"elif"		kw
 	"else"		kw
 	"except"	kw
-	"exec"		kw
 	"finally"	kw
 	"for"		kw
 	"from"		kw
@@ -102,7 +103,6 @@
 	"not"		kw
 	"or"		kw
 	"pass"		kw
-	"print"		kw
 	"raise"		kw
 	"return"	kw
 	"try"		kw


### PR DESCRIPTION
The keywords now match python 3.x instead of python 2.x