### PR TITLE
finding start of character in autocomplete()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@
 
 unreleased
 
+  * Fixed issue where autocomplete could fail/crash with UTF-8 characters.
+
   * Fixed issue where file requester could return incorrect path
     to the selected file.
 

--- a/src/autocomp.c
+++ b/src/autocomp.c
@@ -44,18 +44,18 @@ static void search_buff(const buffer *b, char * p, const int encoding, const boo
 		int64_t l = 0, r = 0;
 		do {
 			/* find left edge of word */
-			while (l < ld->line_len - p_len && !ne_isword(get_char(&ld->line[l], b->encoding), b->encoding)) l += get_char_width(&ld->line[l], b->encoding);
+			while (l < ld->line_len - p_len && !ne_isword(get_char(&ld->line[l], b->encoding), b->encoding)) l = next_pos(ld->line, l, b->encoding);
 			if (l < ld->line_len - p_len ) {
 				int ch;
 				/* find right edge of word */
-				r = l + get_char_width(&ld->line[l], b->encoding);
+				r = next_pos(ld->line, l, b->encoding);
 				/* accept "'" as a word character if it is followed by another word character, so that
 				   words like "don't" are not broken into "don" and "t". */
 				while (r < ld->line_len
-				       && (    ne_isword(ch=get_char(&ld->line[r], b->encoding), b->encoding)
+				       && ( ne_isword(ch=get_char(&ld->line[r], b->encoding), b->encoding)
 				            || ( r+1 < ld->line_len && ch == '\'' && ne_isword(get_char(&ld->line[r+1], b->encoding), b->encoding))
 				          )
-				      ) r += get_char_width(&ld->line[r], b->encoding);
+				      ) r = next_pos(ld->line, r, b->encoding);
 				if ((b != cur_buffer || ld != b->cur_line_desc || b->cur_pos < l || r < b->cur_pos)
 				     && r - l > p_len && (b->encoding == encoding || is_ascii(&ld->line[l], r - l))
 				     && !cmp(p, &ld->line[l], p_len))
@@ -79,7 +79,7 @@ static void search_buff(const buffer *b, char * p, const int encoding, const boo
    if it is non-NULL (a returned NULL means that no completion is available).
 
    If there is more than one completion, this function will invoke request_strings()
-   (and subsequently reset_window()) after displaying req_msg. In any case, error 
+   (and subsequently reset_window()) after displaying req_msg. In any case, error
    will contain a value out of those in the enum info that start with AUTOCOMPLETE_. */
 
 char *autocomplete(char *p, char *req_msg, const int ext, int * const error) {
@@ -143,13 +143,13 @@ char *autocomplete(char *p, char *req_msg, const int ext, int * const error) {
 		if (rl.entries[0][m-1] == EXTERNAL_FLAG_CHAR) m--;
 		for(int i = 1; i < rl.cur_entries; i++) {
 			int j;
-			for(j = 0; j < m; j++) 
+			for(j = 0; j < m; j++)
 				if (rl.entries[i][j] != rl.entries[0][j]) break;
 			m = j;
 		}
 
 		/* If we can output more characters than the prefix len, we do so without
-			starting the requester. */
+		   starting the requester. */
 		if (m > prefix_len) {
 			p = malloc(m + 1);
 			strncpy(p, rl.entries[0], m);

--- a/src/request.c
+++ b/src/request.c
@@ -593,8 +593,10 @@ static int rebuild_rl_entries() {
 	for (i = j = n = 0; i < rl0->cur_entries; i++) {
 		int orig = reverse_reorder(i);
 		char * const p1 = rl0->entries[orig];
-		D(fprintf(stderr, "rre: i:%d, j:%d, n:%d p0:%x p1:%x fuzz_len:%d rl.prune:%d\n",
-		       i, j, n, p0, p1, fuzz_len, rl.prune);)
+		D(fprintf(stderr, "rre: i:%d, j:%d, n:%d p0:%lx p1:%lx fuzz_len:%d rl.prune:%d\n",
+		                          i,    j,    n,
+		                            (unsigned long) p0,
+		                                   (unsigned long) p1,          fuzz_len,  rl.prune);)
 		if ( ! rl.prune || ! strncasecmp(p0, p1, fuzz_len) ) {
 			if (p1 == p0) {
 				n = j;
@@ -602,7 +604,7 @@ static int rebuild_rl_entries() {
 			}
 			rl.entries[j] = p1;
 			rl.lengths[j++] = rl0->lengths[orig];
-			D(fprintf(stderr, "rre: set rl.entries[%d] <- %x ('%s')\n", j-1, p1, p1);)
+			D(fprintf(stderr, "rre: set rl.entries[%d] <- %lx ('%s')\n", j-1, (unsigned long) p1, p1);)
 			D(fprintf(stderr, "rre: set rl.lengths[%d] <- rl0->lengths[%d] (%d)\n", j-1, orig, rl0->lengths[orig]);)
 		}
 	}


### PR DESCRIPTION
Use `next_pos()` rather than `get_char_width()` to find start of characters in `autocomplete()`.

`next_pos()` finds the first byte of the next character in a byte array of a given encoding.

`get_char_width()` returns the number of columns required to display a character.

Both extremely useful, but hardly interchangeable.