### PR TITLE
[Bugfix] Add Further File Extensions to Highlight (#3)

### DIFF
--- a/doc/ne.texinfo
+++ b/doc/ne.texinfo
@@ -4509,22 +4509,27 @@ a list of common extensions. Don't get fancy with this format.
 
 @example
    ada: adb, ads
-   asm: s
-   c: c++, cc, cpp, cxx, h, h++, hpp, l, lex, y, yacc
+   asm: s, S, sx
+   c: asy, C, c++, cc, cp, cpp, CPP, cxx, dox, h, H, h++, hh, hp,
+      hpp, HPP, hxx, i, ii, l, lex, tcc, y, yacc
    cobol: cbl, cob
    csh: tcsh
    diff: patch
-   fortran: f, F, for, f90, F90
+   fortran: f, F, for, FOR, f90, F90, f95, F95, f03, F03, f08,
+            F08, f18, ftn, FTN, fpp, FPP
+   haskell: hs, lhs
    html: htm
    java: js
    lisp: el, lsp
    mason: mas
+   md: markdown
    ocaml: ml, mli
    pascal: p, pas
    perl: pl, pm
+   php: inc, php4, php5
    ps: eps
    puppet: pp
-   python: py, sage
+   python: py, pyw, pyx, sage
    rexx: rex
    ruby: rb
    sh: bash, bash_login, bash_logout, bash_profile, bashrc, ksh,
@@ -4532,10 +4537,10 @@ a list of common extensions. Don't get fancy with this format.
    skill: il
    tex: latex, dtx, sty
    texinfo: texi, txi
-   troff: 1
-   verilog: v, vh, vhd
+   troff: 1, 3
+   verilog: v, vh, vhd, vhdl
    xml: xsd
-   yaml: yml
+   yaml: cff, yml
 @end example
 
 


### PR DESCRIPTION
This Pull Request incorporates the ideas of #104 and adds further file extensions to the syntax highlight mapping.  The commit message contains references where the extensions originate from and which applications work with them.  Most of the new extensions originate from Doxygen and GCC.

Extensions were added for the following languages.

* Assembler
* C
* Fortran
* Haskell
* Markdown
* PHP
* Python
* Troff
* Verilog
* YAML

Doxygen is a popular and common documentation tool.  The extensions it supports are hence expected to occur as input files to be edited with ne.  GCC is a very important compiler and was thus my main reference to counter-check the extensions supported by Doxygen as the Doxygen configuration file only lists the supported extensions without a mapping information.

I added Haskell and PHP as they were subject to #104 as well as Asymptote and CFF (see #102) since I usually work with those latter two languges.  Asymptote (`asy`) is a vector graphics language inspired by both C and Java, thus, it shares some syntax elements with both.  I shelved it in to the C section, initially.  If one finds that it is rather similar to Java instead of C, moving it there is no problem, please just tell me.