### PR TITLE
[Enhancement] Create .bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 3.3.2
+
+[bumpversion:file:makefile]
+
+[bumpversion:file:ne.spec]
+replace = Version: {new_version}
+search = Version: {current_version}


### PR DESCRIPTION
This Pull Request introduces a self-maintaining configuration file in order to abbreviate the process of incrementing the current version number in multiple files.  This configuration file was already mentioned in #102 and controls the behaviour of an MIT-licensed Python 3-CLI named `bump2version`:

Verkerk, C., & The bump2version Community. (2020). bump2version (Version 1.0.2-dev) [Computer software]. https://github.com/c4urself/bump2version

When preparing a new release, the version number needs to be updated.  Version numbers often appear as magic numbers in multiple files.  `bump2version` helps to increment them.  The configuration just needs to know the current version number and the files to update.  When calling it, the tracked files *as well as the configuration file itself* will be set to the new version number.  This is why I named this configuration file "self-maintaining".

Version numbers are considered to meet the pattern `major.minor.patch`.  To increment from 3.3.2 to, say, 4.0.0, `bump2version` can be called as follows:

```bash
bump2version major
```

Other version increments are triggered similarly.  The CLI will complain when they are uncommitted changes.  To override and, hence, ignore this complaint, there is the option `--allow-dirty`.

There are further options to auto-commit and, if so, also auto-tag the new version.  They are disabled, by default, and can be activated either once with command line options or permanently by the corresponding entries to the configuration file.  [The project's README](https://github.com/c4urself/bump2version/blob/master/README.md) provides a comprehensive explanation of all command line options and the corresponding keys for the configuration file.  There are also many examples in the README.

This Pull Request is intended to make the process of preparing a new version easier by reducing the required steps to a call to a portable, free and open source CLI, controlled by a self-maintaining configuration file.  The initial setup adds all sane occurrences of the version number to the scope of `bump2version`:  line 5 of the `makefile` (`VERSION=3.3.2`) as well as line 3 of `ne.spec` (`Version: 3.3.2`).  All other occurrences (`git grep 3.3.2`) were not added since I considered them constant.  Whenever a new file is introduced which contains the version number, it can be added to `.bumpversion.cfg` to be updated automatically, as well.