### PR TITLE
Disable standout before clearing lines

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -650,6 +650,7 @@ void move_cursor (const int row, const int col) {
 void clear_end_of_line(const int first_unused_hpos) {
 	if (curX >= first_unused_hpos) return;
 
+	if (standout_mode) turn_off_standout();
 	if (curr_attr & BG_NOT_DEFAULT) set_attr(0);
 	if (ne_clr_eol) OUTPUT1 (ne_clr_eol);
 	else {


### PR DESCRIPTION
This is a long-running problem that I've muddled around in the past.

* Start ``ne`` in [zutty](https://tomscii.sig7.se/zutty/) or [termux](https://termux.dev/en/) via SSH, both use ``TERM=xterm-256color``. I'm fairly sure there are other terminals also affected, maybe some of the Javascript terminals?
* Press enter to clear welcome message, screen goes white.
* Type ``sdf`` and press Ctrl-l. Screen restored, bar top line.
* Press enter, line ends in white highlight, following line also white. Ctrl-l clears
* Type ``sdf { hello }``, press left so right braces are highlighted, press enter. No highlight problems.

This appears to be caused by standout_mode being enabled when a line is being cleared. Calling ``turn_off_standout()`` solves the problem as far as I can see.

Note that ``standout_mode`` is a separate state to ``curr_attr``, so generally ``curr_attr`` is 0 when pressing enter. However, for the braces above attributes are set on them, so we call ``set_attr(0)`` here which also disables the reverse-video. Thus why the final case works fine.

Arguably the terminals are the ones at fault, given they claim they're xterm and this isn't something xterm does, but I don't know if I'd win that argument with the terminal developers :)