### PR TITLE
Pass flags to clang and fix POSIX none-compliance

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -95,14 +95,21 @@ CC=c99
 endif
 
 # Test for GCC
-ifneq (,$(findstring gcc,$(shell $(CC) 2>&1)))
+
+GCC=$(findstring gcc,$(shell $(CC) 2>&1))
+CLANG=$(findstring clang,$(shell $(CC) 2>&1))
+
+ifneq (,$(or $(GCC), $(CLANG)))
+CC=cc
 GCCFLAGS=-std=c99 -Wall -Wno-parentheses -fno-strict-aliasing -Wp,-D_FORTIFY_SOURCE=2
 
+ifneq (,$(GCC))
 # link-time optimizer only on GCC 4.6+
 GCC_VERSION_GT_46=$(shell expr `$(CC) -dumpversion` ">=" 4.6)
 ifeq ($(GCC_VERSION_GT_46),1)
 GCCFLAGS+= -flto=auto -ffat-lto-objects 
 LDFLAGS=-flto=auto
+endif
 endif
 
 endif


### PR DESCRIPTION
The code was detecting only `gcc` and the flags were not passed to `clang`.

However, surprisingly, those flags will be rejected with a mythical error message. It turns out the `c99` executable as written in the standard only have a few flags. Apple, for whatever reason I don't want to know, ships a real `c99` executable for macOS that would reject those extra flags. 

So, stay with `cc` when using gcc/clang and pass identical flags to both of them. TBH, I think they are the only two that matters nowadays.

+ https://pubs.opengroup.org/onlinepubs/9699919799/utilities/c99.html

