### PR TITLE
Publish documentation to Github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+     branches:
+       - master
+  workflow_dispatch:
+
+name: Render documentation
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build-prerequisites
+        run: sudo apt install --no-install-recommends build-essential libncurses-dev perl texinfo texlive-latex-base texlive-fonts-recommended
+
+      - name: Build HTML docs
+        run: make -C doc html/index.html
+
+      - name: Build PDF docs
+        run: make -C doc ne.pdf
+
+      - name: Copy parts to deploy dir
+        run: mkdir gh-pages && cp -r doc/html gh-pages/docs && cp -r doc/ne.pdf gh-pages/
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages/
+          destination_dir: ./


### PR DESCRIPTION
Since [ne.di.unimi.it/](http://ne.di.unimi.it/) went away, not having a website with the rendered documentation has been a bit sad. Would you be interested in something like the following to publish to Github Pages?

Here's an example of a run: https://github.com/lentinj/ne/actions/runs/21731282001/job/62686229374
The documentation ends up here: https://lentinj.github.io/ne/docs/ & https://lentinj.github.io/ne/ne.pdf (or https://vigna.github.io/ne/docs once it's merged)

For this to work you'd need to enable deploying from the "gh-pages" branch here https://github.com/vigna/ne/settings/pages

I've left a gap in the site structure for the old index page, if you wanted to add that back.