### PR TITLE
Added gemtext syntax file

### DIFF
--- a/syntax/gmi.jsf
+++ b/syntax/gmi.jsf
@@ -1,0 +1,89 @@
+# JOE syntax highlight file for Gemtext by Skylar Gallup (https://skyebound.gay)
+
+=Idle
+=Headline	bold yellow
+=Quote		green
+=Pre		green
+=List		yellow
+=LinkDesc	green
+=Link		blue
+
+:line_start	Idle
+	*		idle		noeat
+	"="		maybe_link
+	"#"		heading1	recolor=-1
+	"*"		list 		recolor=-1
+	">"		quote		recolor=-1
+	"`"		maybe_pre1
+
+:idle		Idle
+	*		idle
+	"\n"	line_start
+
+:maybe_link		Idle
+	*			idle
+	">"			probably_link
+	"\n"		line_start
+
+:probably_link	Idle
+	*			link		recolor=-3
+	" "			link		recolor=-3
+	"\n"		line_start
+
+:link		Link
+	*		link
+	" "		link_desc
+	"\n"	line_start
+
+:link_desc	LinkDesc
+	*		link_desc
+	"\n"	line_start
+
+:heading 	Headline
+	*		heading
+	"\n"	line_start
+
+:heading1	Headline
+	*		heading
+	"#"		heading2
+	"\n"	line_start
+
+:heading2	Headline
+	*		heading
+	"#"		heading3
+	"\n"	line_start
+
+:heading3	Headline
+	*		heading
+	"#"		idle		recolor=-4
+	"\n"	line_start
+
+:quote		Quote
+	*		quote
+	"\n"	line_start
+
+:list		List
+	*		list
+	"\n"	line_start
+
+:maybe_pre1	Idle
+	*		idle
+	"`"		maybe_pre2
+	"\n"	line_start
+
+:maybe_pre2	Idle
+	*		idle
+	"`"		pre			recolor=-3
+	"\n"	line_start
+
+:pre		Pre
+	*		pre
+	"`" 	maybe_end_pre1
+
+:maybe_end_pre1	Pre
+	*		pre
+	"`"		maybe_end_pre2
+
+:maybe_end_pre2	Pre
+	*		pre
+	"`"		idle


### PR DESCRIPTION
This PR adds a syntax highlighting file for the "gemtext" hypertext format (`.gmi`), as used by the [Gemini web protocol](https://geminiprotocol.net/). This file format is similar to Markdown in a lot of ways, so the colors I chose map to those chosen in the [existing Markdown syntax file](https://github.com/vigna/ne/blob/master/syntax/md.jsf).

For reference, see the formal specification for gemtext at [https://geminiprotocol.net/docs/gemtext-specification.gmi](https://geminiprotocol.net/docs/gemtext-specification.gmi).

<img width="722" height="562" alt="Screenshot 2026-08-09 at 5 56 53 AM" src="https://github.com/user-attachments/assets/8ba10b0b-2d26-4abf-8a99-70729d9b8912" />

Resolves #129.